### PR TITLE
Avoid JavaScript security warning

### DIFF
--- a/src/components/vue-wxlogin.vue
+++ b/src/components/vue-wxlogin.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <iframe scrolling="no" width="300" height="400" frameBorder="0" allowTransparency="true" :src="setSrc"></iframe>
+    <iframe sandbox="allow-scripts allow-top-navigation" scrolling="no" width="300" height="400" frameBorder="0" allowTransparency="true" :src="setSrc"></iframe>
   </div>
 </template>
 


### PR DESCRIPTION
Avoid JavaScript security warning in Chome
```
Unsafe JavaScript attempt to initiate navigation for frame with URL
```