### PR TITLE
fix: The document is sandboxed and lacks the 'allow-same-origin' flag…

### DIFF
--- a/src/components/vue-wxlogin.vue
+++ b/src/components/vue-wxlogin.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <iframe sandbox="allow-scripts allow-top-navigation" scrolling="no" width="300" height="400" frameBorder="0" allowTransparency="true" :src="setSrc"></iframe>
+    <iframe sandbox="allow-scripts allow-top-navigation allow-same-origin" scrolling="no" width="300" height="400" frameBorder="0" allowTransparency="true" :src="setSrc"></iframe>
   </div>
 </template>
 


### PR DESCRIPTION
Fix Failed to read the 'cookie' property from 'Document' error

more detail [link](https://developers.weixin.qq.com/community/develop/doc/000860f9f88b28fae761bf13e61000?commentid=0008a8ee664970ece261230d06b8)